### PR TITLE
feat: add help by default in SARIF

### DIFF
--- a/bin/codeql-analyze
+++ b/bin/codeql-analyze
@@ -4,8 +4,14 @@ source $EXTENSION_LOCATION/bin/codeql-utils
 
 CODEQL_DATABASE_PATHS=$(cat $CODEQL_DATABASE_PATHS_FILE)
 
+CODEQL_ADD_HELP="--sarif-add-query-help"
+
 for i in "$@"; do
   case $i in
+    --ignore-sarif-query-help)
+        CODEQL_ADD_HELP=""
+        shift
+        ;;
     --disable-uploading)
         GITHUB_UPLOAD=0
         shift
@@ -44,6 +50,7 @@ for CODEQL_DATABASE in $CODEQL_DATABASE_PATHS ; do
     # TODO: custom QL suites
     # The --sarif-category must be set in case of multiple databases
     $CODEQL_BINARY database analyze \
+        $CODEQL_ADD_HELP \
         --format="sarif-latest" \
         --sarif-category="${DATABASE}" \
         --output=$CODEQL_SARIF \


### PR DESCRIPTION
The option `--sarif-add-query-help` add the qlhelp content to the SARIF.
We should make it available here, and I think it could be better to have it by default