### PR TITLE
Fix MacOS memory calculation in MB instead of bytes

### DIFF
--- a/bin/codeql-utils
+++ b/bin/codeql-utils
@@ -143,7 +143,7 @@ memory() {
     # Get the memory of the system
     if [[ "$OSTYPE" == "darwin"* ]]; then
         # MacOS
-        MEMORY=$(sysctl -n hw.memsize)
+        MEMORY=$(($(sysctl -n hw.memsize) / 1024 / 1024))
     else
         # Linux
         MEMORY=$(free -m | awk 'NR==2{print $2}')


### PR DESCRIPTION
## Problem
Running codeql-scan would fail when creating/analyzing the database, because they are using a memory function

## Tracing the issue
Running `sysctl -n hw.memsize` prints total memory in bytes where the script is using memory in MB

## Solution
Converting byte value to MB in darwin OS